### PR TITLE
feat: redirect logged-in users from homepage to dashboard

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,16 @@
 import Image from "next/image";
+import { auth } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
 
-export default function Home() {
+export default async function Home() {
+  // Check if user is logged in
+  const { userId } = await auth();
+
+  // If user is authenticated, redirect to dashboard
+  if (userId) {
+    redirect("/dashboard");
+  }
+
   return (
     <div className="flex min-h-screen items-center justify-center bg-zinc-50 font-sans dark:bg-black">
       <main className="flex min-h-screen w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">


### PR DESCRIPTION
When a user is authenticated and visits the root page (/), they are now automatically redirected to the /dashboard page. This improves UX by taking users directly to their workout tracking interface.

- Added auth check using Clerk's auth() function
- Added redirect logic to homepage server component
- Follows authentication patterns from docs/auth.md

Fixes #3

🤖 Generated with [Claude Code](https://claude.ai/code)