### PR TITLE
fix: protect /dashboard routes with Clerk authentication middleware

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,6 +1,16 @@
-import { clerkMiddleware } from "@clerk/nextjs/server";
+import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 
-export default clerkMiddleware();
+const isPublicRoute = createRouteMatcher([
+  '/sign-in(.*)',
+  '/sign-up(.*)',
+  '/',
+]);
+
+export default clerkMiddleware(async (auth, request) => {
+  if (!isPublicRoute(request)) {
+    await auth.protect();
+  }
+});
 
 export const config = {
   matcher: [


### PR DESCRIPTION
Updated src/proxy.ts to add route protection:
- Added createRouteMatcher to define public routes (/, /sign-in, /sign-up)
- Configured middleware to call auth.protect() for all non-public routes
- This prevents the 500 "Unauthorized" error when accessing /dashboard while logged out
- Unauthenticated users are now redirected to sign-in before the page loads

Fixes #5

🤖 Generated with [Claude Code](https://claude.ai/code)