### PR TITLE
Enable dark mode for entire site

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,7 +32,7 @@ export default function RootLayout({
 }>) {
   return (
     <ClerkProvider>
-      <html lang="en">
+      <html lang="en" className="dark">
         <body
           className={`${geistSans.variable} ${geistMono.variable} antialiased`}
         >


### PR DESCRIPTION
Added 'dark' class to html element to enable dark mode styling across the entire application. The site already had dark mode CSS variables and component variants defined.

Fixes #7